### PR TITLE
Adding negative tabindex

### DIFF
--- a/Form/Type/HoneypotType.php
+++ b/Form/Type/HoneypotType.php
@@ -80,6 +80,7 @@ class HoneypotType extends AbstractType
             'data'     => '',
             'attr'     => array(
                 'autocomplete' => 'off',
+                'tabindex' => -1,
                 // Fake `display:none` css behaviour to hide input
                 // as some bots may also check inputs visibility
                 'style' => 'position: absolute; left: -100%; top: -100%;'


### PR DESCRIPTION
When a person uses tabs to navigate through a form with a honeypot-field, that field will be selected as well.

I've added a negative tabindex to disable this behavior.
