### PR TITLE
Refactored HoneypotType

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-	<parameters>
+    <parameters>
         <parameter key="eo_honeypot.manager.class">Eo\HoneypotBundle\Manager\HoneypotManager</parameter>
         <parameter key="eo_honeypot.form.type.class">Eo\HoneypotBundle\Form\Type\HoneypotType</parameter>
     </parameters>
 
-	<services>
-		<!-- Honeypot Manager -->
+    <services>
+        <!-- Honeypot Manager -->
         <service id="eo_honeypot.manager" class="%eo_honeypot.manager.class%">
             <argument>%eo_honeypot.options%</argument>
         </service>
+
         <!-- Form Type -->
-        <service id="eo_honeypot.form.type.honeypot" class="%eo_honeypot.form.type.class%">
-            <argument type="service" id="service_container"/>
+        <service id="eo_honeypot.form.type.honeypot" class="%eo_honeypot.form.type.class%" scope="request">
+            <argument type="service" id="request"/>
+            <argument type="service" id="eo_honeypot.manager"/>
+            <argument type="service" id="event_dispatcher"/>
             <tag name="form.type" alias="honeypot" />
         </service>
-	</services>
+    </services>
 
 </container>


### PR DESCRIPTION
Hi,

I just moved the form type to the `request` scope in order to remove the `container` injection. I didn't use the RequestStack to stay compatible with sf < 2.4.

I also refactored a bit the files.
