### PR TITLE
Remove request injection from RedirectListener

### DIFF
--- a/EventListener/RedirectListener.php
+++ b/EventListener/RedirectListener.php
@@ -4,7 +4,6 @@ namespace Eo\HoneypotBundle\EventListener;
 use Eo\HoneypotBundle\Manager\HoneypotManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\Routing\RouterInterface;
@@ -12,14 +11,12 @@ use Symfony\Component\Routing\RouterInterface;
 class RedirectListener
 {
     protected $router;
-    protected $request;
     protected $honeypotManager;
     protected $eventDispatcher;
 
-    public function __construct(RouterInterface $router, Request $request, HoneypotManager $honeypotManager, EventDispatcherInterface $eventDispatcher)
+    public function __construct(RouterInterface $router, HoneypotManager $honeypotManager, EventDispatcherInterface $eventDispatcher)
     {
         $this->router = $router;
-        $this->request = $request;
         $this->honeypotManager = $honeypotManager;
         $this->eventDispatcher = $eventDispatcher;
     }
@@ -46,7 +43,7 @@ class RedirectListener
         } elseif ($route) {
             $target = $this->router->generate($route, $parameters);
         } else {
-            $target = $this->request->getUri();
+            $target = $event->getRequest()->getUri();
         }
 
         $event->setResponse(new RedirectResponse($target));

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,9 +26,8 @@
         </service>
 
         <!-- RedirectListener -->
-        <service id="eo_honeypot.redirect_listener" class="%eo_honeypot.redirect_listener.class%" scope="request">
+        <service id="eo_honeypot.redirect_listener" class="%eo_honeypot.redirect_listener.class%">
             <argument type="service" id="router"/>
-            <argument type="service" id="request"/>
             <argument type="service" id="eo_honeypot.manager"/>
             <argument type="service" id="event_dispatcher"/>
             <tag name="kernel.event_listener" event="%eo_honeypot.event.bird_in_cage%" method="onBirdInCage" />


### PR DESCRIPTION
This PR removes useless `request` injection in the `RedirectListener`, which was moreover causing issues with the Web Profiler.
