### PR TITLE
Setting position to fixed instead of absolute

### DIFF
--- a/Form/Type/HoneypotType.php
+++ b/Form/Type/HoneypotType.php
@@ -85,7 +85,7 @@ class HoneypotType extends AbstractType
                 'tabindex' => -1,
                 // Fake `display:none` css behaviour to hide input
                 // as some bots may also check inputs visibility
-                'style' => 'position: absolute; left: -100%; top: -100%;'
+                'style' => 'position: fixed; left: -100%; top: -100%;'
             )
         ));
     }


### PR DESCRIPTION
Changed the style from `position: fixed` to `position:absolute` because I was running into some issues with the parent item being `position:relative`. That resulted in the honeypot element being displayed on the page.

When using **fixed** the element doesn't care about the parent item.
