### PR TITLE
Fix problem when using the web browser's autocomplete feature

### DIFF
--- a/Form/Type/HoneypotType.php
+++ b/Form/Type/HoneypotType.php
@@ -99,7 +99,8 @@ class HoneypotType extends AbstractType
             'mapped'   => false,
             'data'     => '',
             'attr'     => array(
-                'autocomplete' => 'off',
+                //autocomplete="off" does not work in some cases, random strings always do
+                'autocomplete' => 'nope',
                 'tabindex' => -1,
                 // Fake `display:none` css behaviour to hide input
                 // as some bots may also check inputs visibility


### PR DESCRIPTION
autocomplete="off" does not work in some cases, leaving the
user alone with an unsendable form. Setting
autocomplete="somerandomstring" works, so I propose setting it to "nope".

See https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion